### PR TITLE
Update HomeostaticPlasticityController.cs

### DIFF
--- a/source/NeoCortexApi/HomeostaticPlasticityController.cs
+++ b/source/NeoCortexApi/HomeostaticPlasticityController.cs
@@ -359,7 +359,7 @@ namespace NeoCortexApi
                 return false;
             else if (m_RequiredNumOfStableCycles != obj.m_RequiredNumOfStableCycles)
                 return false;
-            else if (!m_NumOfStableCyclesForInput.SequenceEqual(obj.m_NumOfStableCyclesForInput) && !m_NumOfActiveColsForInput.SequenceEqual(m_NumOfActiveColsForInput) && !m_InOutMap.SequenceEqual(m_InOutMap))
+            else if (!m_NumOfStableCyclesForInput.SequenceEqual(obj.m_NumOfStableCyclesForInput) && !m_NumOfActiveColsForInput.SequenceEqual(obj.m_NumOfActiveColsForInput) && !m_InOutMap.SequenceEqual(obj.m_InOutMap))
                 return false;
             else if (m_IsStable != obj.m_IsStable)
                 return false;


### PR DESCRIPTION
Hi @ddobric,
I am writing Unit Tests for HomeostaticPlasticityController class.
Currently writing tests for Equals method, to describe this function briefly, it compares two HomeostaticPlasticityController objects and takes one HomeostaticPlasticityController object as argument.

In the following original piece of code from Equals method, m_NumOfActiveColsForInput and m_InOutMap are being compared with themselves. I think it would make more sense, it these variables are compared with the argument HomeostaticPlasticityController object.

`else if (!m_NumOfStableCyclesForInput.SequenceEqual(obj.m_NumOfStableCyclesForInput) && !m_NumOfActiveColsForInput.SequenceEqual(m_NumOfActiveColsForInput) && !m_InOutMap.SequenceEqual(m_InOutMap))`
