### PR TITLE
Htm classifier int array

### DIFF
--- a/source/NeoCortexApi/Classifiers/HtmClassifier.cs
+++ b/source/NeoCortexApi/Classifiers/HtmClassifier.cs
@@ -343,13 +343,14 @@ namespace NeoCortexApi.Classifiers
         /// <summary>
         /// Traces out all cell indicies grouped by input value.
         /// </summary>
-        public void TraceState(string fileName = null)
+        public string TraceState(string fileName = null)
         {
+            StringWriter strSw = new StringWriter();
+
             StreamWriter sw = null;
+
             if (fileName != null)
                 sw = new StreamWriter(fileName);
-            else
-                sw = new StreamWriter(fileName.Replace(".csv", "HtmClassifier.state.csv"));
 
             List<TIN> processedValues = new List<TIN>();
 
@@ -357,36 +358,37 @@ namespace NeoCortexApi.Classifiers
             // Trace out the last stored state.
             foreach (var item in this.m_AllInputs)
             {
-                Debug.WriteLine("");
-                Debug.WriteLine($"{item.Key}");
-                Debug.WriteLine($"{Helpers.StringifyVector(item.Value.Last())}");
+                strSw.WriteLine("");
+                strSw.WriteLine($"{item.Key}");
+                strSw.WriteLine($"{Helpers.StringifyVector(item.Value.Last())}");
+            }
+
+            strSw.WriteLine("........... Cell State .............");
+
+            foreach (var item in m_AllInputs)
+            {
+                strSw.WriteLine("");
+
+                strSw.WriteLine($"{item.Key}");
+
+                strSw.Write(Helpers.StringifySdr(new List<int[]>(item.Value)));
+
+                //foreach (var cellState in item.Value)
+                //{
+                //    var str = Helpers.StringifySdr(cellState);
+                //    strSw.WriteLine(str);
+                //}
             }
 
             if (sw != null)
             {
+                sw.Write(strSw.ToString());
                 sw.Flush();
                 sw.Close();
             }
 
-            Debug.WriteLine("........... Cell State .............");
-
-            using (var cellStateSw = new StreamWriter(fileName.Replace(".csv", "HtmClassifier.fullstate.csv")))
-            {
-                foreach (var item in m_AllInputs)
-                {
-                    Debug.WriteLine("");
-                    Debug.WriteLine($"{item.Key}");
-
-                    cellStateSw.WriteLine("");
-                    cellStateSw.WriteLine($"{item.Key}");
-                    foreach (var cellState in item.Value)
-                    {
-                        var str = Helpers.StringifyVector(cellState);
-                        Debug.WriteLine(str);
-                        cellStateSw.WriteLine(str);
-                    }
-                }
-            }
+            Debug.WriteLine(strSw.ToString());
+            return strSw.ToString();
         }
 
 

--- a/source/NeoCortexApi/Classifiers/HtmClassifier.cs
+++ b/source/NeoCortexApi/Classifiers/HtmClassifier.cs
@@ -116,6 +116,11 @@ namespace NeoCortexApi.Classifiers
         {
             var cellIndicies = GetCellIndicies(output);
 
+            Learn(input, cellIndicies);
+        }
+
+        public void Learn(TIN input, int[] cellIndicies)
+        {
             if (m_AllInputs.ContainsKey(input) == false)
                 m_AllInputs.Add(input, new List<int[]>());
 
@@ -146,7 +151,12 @@ namespace NeoCortexApi.Classifiers
             }
         }
 
+        public List<ClassifierResult<TIN>> GetPredictedInputValues(Cell[] predictiveCells, short howMany = 1)
+        {
+            var cellIndicies = GetCellIndicies(predictiveCells);
 
+            return GetPredictedInputValues(cellIndicies, howMany);
+        }
 
         /// <summary>
         /// Gets multiple predicted values.
@@ -154,7 +164,7 @@ namespace NeoCortexApi.Classifiers
         /// <param name="predictiveCells">The current set of predictive cells.</param>
         /// <param name="howMany">The number of predections to return.</param>
         /// <returns>List of predicted values with their similarities.</returns>
-        public List<ClassifierResult<TIN>> GetPredictedInputValues(Cell[] predictiveCells, short howMany = 1)
+        public List<ClassifierResult<TIN>> GetPredictedInputValues(int[] cellIndicies, short howMany = 1)
         {
             List<ClassifierResult<TIN>> res = new List<ClassifierResult<TIN>>();
             double maxSameBits = 0;
@@ -162,15 +172,13 @@ namespace NeoCortexApi.Classifiers
             Dictionary<TIN, ClassifierResult<TIN>> dict = new Dictionary<TIN, ClassifierResult<TIN>>();
 
             var predictedList = new List<KeyValuePair<double, string>>();
-            if (predictiveCells.Length != 0)
+            if (cellIndicies.Length != 0)
             {
                 int indxOfMatchingInp = 0;
-                Debug.WriteLine($"Item length: {predictiveCells.Length}\t Items: {this.m_AllInputs.Keys.Count}");
+                Debug.WriteLine($"Item length: {cellIndicies.Length}\t Items: {this.m_AllInputs.Keys.Count}");
                 int n = 0;
 
                 List<int> sortedMatches = new List<int>();
-
-                var cellIndicies = GetCellIndicies(predictiveCells);
 
                 Debug.WriteLine($"Predictive cells: {cellIndicies.Length} \t {Helpers.StringifyVector(cellIndicies)}");
 
@@ -335,14 +343,13 @@ namespace NeoCortexApi.Classifiers
         /// <summary>
         /// Traces out all cell indicies grouped by input value.
         /// </summary>
-        public string TraceState(string fileName = null)
+        public void TraceState(string fileName = null)
         {
-            StringWriter strSw = new StringWriter();
-
             StreamWriter sw = null;
-
             if (fileName != null)
                 sw = new StreamWriter(fileName);
+            else
+                sw = new StreamWriter(fileName.Replace(".csv", "HtmClassifier.state.csv"));
 
             List<TIN> processedValues = new List<TIN>();
 
@@ -350,37 +357,36 @@ namespace NeoCortexApi.Classifiers
             // Trace out the last stored state.
             foreach (var item in this.m_AllInputs)
             {
-                strSw.WriteLine("");
-                strSw.WriteLine($"{item.Key}");
-                strSw.WriteLine($"{Helpers.StringifyVector(item.Value.Last())}");
-            }
-
-            strSw.WriteLine("........... Cell State .............");
-
-            foreach (var item in m_AllInputs)
-            {
-                strSw.WriteLine("");
-
-                strSw.WriteLine($"{item.Key}");
-
-                strSw.Write(Helpers.StringifySdr(new List<int[]> (item.Value)));
-
-                //foreach (var cellState in item.Value)
-                //{
-                //    var str = Helpers.StringifySdr(cellState);
-                //    strSw.WriteLine(str);
-                //}
+                Debug.WriteLine("");
+                Debug.WriteLine($"{item.Key}");
+                Debug.WriteLine($"{Helpers.StringifyVector(item.Value.Last())}");
             }
 
             if (sw != null)
             {
-                sw.Write(strSw.ToString());
                 sw.Flush();
                 sw.Close();
             }
 
-            Debug.WriteLine(strSw.ToString());
-            return strSw.ToString();
+            Debug.WriteLine("........... Cell State .............");
+
+            using (var cellStateSw = new StreamWriter(fileName.Replace(".csv", "HtmClassifier.fullstate.csv")))
+            {
+                foreach (var item in m_AllInputs)
+                {
+                    Debug.WriteLine("");
+                    Debug.WriteLine($"{item.Key}");
+
+                    cellStateSw.WriteLine("");
+                    cellStateSw.WriteLine($"{item.Key}");
+                    foreach (var cellState in item.Value)
+                    {
+                        var str = Helpers.StringifyVector(cellState);
+                        Debug.WriteLine(str);
+                        cellStateSw.WriteLine(str);
+                    }
+                }
+            }
         }
 
 

--- a/source/NeoCortexApi/Classifiers/HtmClassifier.cs
+++ b/source/NeoCortexApi/Classifiers/HtmClassifier.cs
@@ -111,7 +111,6 @@ namespace NeoCortexApi.Classifiers
         /// </summary>
         /// <param name="input">Any kind of input.</param>
         /// <param name="output">The SDR of the input as calculated by SP.</param>
-        /// <param name="predictedOutput"></param>
         public void Learn(TIN input, Cell[] output)
         {
             var cellIndicies = GetCellIndicies(output);
@@ -119,6 +118,11 @@ namespace NeoCortexApi.Classifiers
             Learn(input, cellIndicies);
         }
 
+        /// <summary>
+        /// Assotiate specified input to the given set of predictive cells. This can also be used to classify Spatial Pooler Columns output as int array
+        /// </summary>
+        /// <param name="input">Any kind of input.</param>
+        /// <param name="output">The SDR of the input as calculated by SP as int array</param>
         public void Learn(TIN input, int[] cellIndicies)
         {
             if (m_AllInputs.ContainsKey(input) == false)
@@ -151,6 +155,12 @@ namespace NeoCortexApi.Classifiers
             }
         }
 
+        /// <summary>
+        /// Gets multiple predicted values.
+        /// </summary>
+        /// <param name="predictiveCells">The current set of predictive cells.</param>
+        /// <param name="howMany">The number of predections to return.</param>
+        /// <returns>List of predicted values with their similarities.</returns>
         public List<ClassifierResult<TIN>> GetPredictedInputValues(Cell[] predictiveCells, short howMany = 1)
         {
             var cellIndicies = GetCellIndicies(predictiveCells);
@@ -159,9 +169,9 @@ namespace NeoCortexApi.Classifiers
         }
 
         /// <summary>
-        /// Gets multiple predicted values.
+        /// Gets multiple predicted values. This can also be used to classify Spatial Pooler Columns output as int array
         /// </summary>
-        /// <param name="predictiveCells">The current set of predictive cells.</param>
+        /// <param name="predictiveCells">The current set of predictive cells in int array.</param>
         /// <param name="howMany">The number of predections to return.</param>
         /// <returns>List of predicted values with their similarities.</returns>
         public List<ClassifierResult<TIN>> GetPredictedInputValues(int[] cellIndicies, short howMany = 1)


### PR DESCRIPTION
Take `Cell{}` to `int[]` conversion outside of [`Learn(...)`](https://github.com/ddobric/neocortexapi/blob/7f3b0098709b61634d9e2f3d7106327df2389eef/source/NeoCortexApi/Classifiers/HtmClassifier.cs#L109-L126) and [`GetPredictedInputValues(...)`](https://github.com/ddobric/neocortexapi/blob/7f3b0098709b61634d9e2f3d7106327df2389eef/source/NeoCortexApi/Classifiers/HtmClassifier.cs#L158-L177) 
to enable calls to these two methods with SDR  as `int[]`
```csharp
// Compute the SDR, cortex layer only contains Spatial Pooler module and Encoder module
var sdr = cortexLayer.Compute(outFile, false) as int[];

// Learn function
classifier.Learn(sample.label, activeColumns);

// Get Predicted Labels
var predictedLabel = classifier.GetPredictedInputValues(sdr, 1);
```
`HtmClassifier` is a tool to associated multiple array with a specified Label. This can potentially applied for Classification for Spatial Pooler, which can output `int[]`. It was not possible because `HtmClassifier`'s method worked previously only with `Cell[]` as input. However because all its computations were in `int[]`, the Conversion in the above-mentioned methods was moved outside and now we can use `HtmClassifier` for Spatial Pooler output.
`Cell[]` was converted to `int[]` via [`GetCellIndicies(...)`]()
```csharp
int[] cellIndicies = GetCellIndicies(predictiveCells);
```